### PR TITLE
Excluding node_modules from source-map-loader

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
             {
                 enforce: "pre",
                 test: /\.js$/,
+                exclude: /node_modules/,
                 loader: "source-map-loader"
             }
         ],


### PR DESCRIPTION
Adding an exclusion for node_modules in the webpack configuration for source-map-loader will stop webpack from looking for source maps for eosjs.

Resolves https://github.com/EOSIO/eosio-web-ide/issues/11