### PR TITLE
add likes action

### DIFF
--- a/contract/talk.cpp
+++ b/contract/talk.cpp
@@ -6,6 +6,7 @@ struct [[eosio::table("message"), eosio::contract("talk")]] message {
     uint64_t    reply_to = {}; // Non-0 if this is a reply
     eosio::name user     = {};
     std::string content  = {};
+    uint64_t    likes    = {};
 
     uint64_t primary_key() const { return id; }
     uint64_t get_reply_to() const { return reply_to; }
@@ -43,5 +44,25 @@ class talk : eosio::contract {
             message.user     = user;
             message.content  = content;
         });
+    }
+
+    // Like a message
+    [[eosio::action]] void like(uint64_t id, eosio::name user) {
+        message_table table{get_self(), 0};
+
+        // Check user
+        require_auth(user);
+
+        auto itr = table.find(id);
+
+        if (itr != table.end()) {
+            auto likes = itr->likes;
+            likes++;
+
+            // Update the message with new likes
+            table.modify(itr, get_self(), [&](auto& message) {
+                message.likes = likes;
+            });
+        }
     }
 };


### PR DESCRIPTION
Add "likes" action to talk contract. 

The following testing was done:

Initially the likes in the messages were 0:
{
  "rows": [{
      "id": 1000,
      "reply_to": 0,
      "user": "bob",
      "content": "This is a new post",
      "likes": 0
    },{
      "id": 1001,
      "reply_to": 2000,
      "user": "bob",
      "content": "Replying to your post",
      "likes": 0
    },{
      "id": 2000,
      "reply_to": 0,
      "user": "jane",
      "content": "This is my first post",
      "likes": 0
    }
  ],
  "more": false
}

After I run "like" operations:

cleos push action talk like '[1000, bob]' -p bob
cleos push action talk like '[1000, bob]' -p bob
cleos push action talk like '[2000, jane]' -p jane

The likes in the messages were updated correctly
gitpod /workspace/eosio-web-ide $ cleos get table talk '' message
{
  "rows": [{
      "id": 1000,
      "reply_to": 0,
      "user": "bob",
      "content": "This is a new post",
      "likes": 2
    },{
      "id": 1001,
      "reply_to": 2000,
      "user": "bob",
      "content": "Replying to your post",
      "likes": 0
    },{
      "id": 2000,
      "reply_to": 0,
      "user": "jane",
      "content": "This is my first post",
      "likes": 1
    }
  ],
"more": false
}